### PR TITLE
Fix: `view_openmessage` "q" quits openmessage instead of everything

### DIFF
--- a/cmd/cmdg/view_openmessage.go
+++ b/cmd/cmdg/view_openmessage.go
@@ -563,7 +563,7 @@ func (ov *OpenMessageView) Run(ctx context.Context) (*MessageViewOp, error) {
 			case "u":
 				return nil, nil
 			case "q":
-				return OpQuit(), nil
+				return nil, nil
 			case input.CtrlP:
 				return OpPrev(), nil
 			case input.CtrlN:


### PR DESCRIPTION
Hi,

a minor fix, but a big annoyance fix, at leas from my perspepective. I'm pretty used from vim that "q" acts as quit buffer and so I automatically press it. But cmdg would quit overall.

Not sure if this is for general population or where you want to go with hotkeys (you are an emacs user right?). put I thought I would at least try to share it.