### PR TITLE
Erase screen on quit

### DIFF
--- a/cmd/cmdg/view_messagelist.go
+++ b/cmd/cmdg/view_messagelist.go
@@ -380,6 +380,10 @@ func (mv *MessageView) Run(ctx context.Context) error {
 	if err := initScreen(); err != nil {
 		return err
 	}
+	defer func() {
+		screen.Clear()
+		screen.Draw()
+	}()
 
 	mkMessagePos := func() {
 		messagePos = map[string]int{}


### PR DESCRIPTION
I added a small enhancement to erase the contents of the screen before quitting. I noticed that the cursor is positioned near the top of the terminal after quitting, with text still visible below the cursor. Usually I manually clear the terminal after quitting to get around this.

Let me know if you have any comments. Thanks!