### PR TITLE
fix scroll display

### DIFF
--- a/cmd/cmdg/view_openmessage.go
+++ b/cmd/cmdg/view_openmessage.go
@@ -179,7 +179,7 @@ func (ov *OpenMessageView) Draw(lines []string, scroll int) error {
 		line,
 		"Scroll %d-%d/%d (%d%%)%s",
 		scroll,
-		scroll+contentSpace,
+		min(scroll+contentSpace, len(lines)),
 		len(lines),
 		min(100,int(100*float64(scroll+contentSpace) / float64(len(lines)))),
 		searching,


### PR DESCRIPTION
If the entire message is on screen, just show the number of lines, not the maximum theoretical number of lines.