### PR TITLE
Show message ID in openmessage view

### DIFF
--- a/cmd/cmdg/view_openmessage.go
+++ b/cmd/cmdg/view_openmessage.go
@@ -266,6 +266,14 @@ func (ov *OpenMessageView) Draw(lines []string, scroll int) error {
 	ov.screen.Printlnf(line, "Labels: %s", labels)
 	line++
 
+	// Message ID
+	if msgid, err := ov.msg.GetHeader(ctx, "Message-ID"); err == nil {
+		ov.screen.Printlnf(line, "Message-ID: %s", msgid)
+		line++
+	} else {
+		ov.errors <- err
+	}
+
 	ov.screen.Printlnf(line, strings.Repeat("—", ov.screen.Width))
 	line++
 


### PR DESCRIPTION
Hi! Thanks for creating this tool. I often use it for my mailing-list-oriented development (linux kernel mostly) and having easy access to the message ID is very useful. I was wondering if you'd consider merging this.

--

For mailing list workflows, it's useful to be able to easily access the message ID of an email. Display it in the openmessage view.