### PR TITLE
gpg: ensure LC_MESSAGES so that regex match the output.

### DIFF
--- a/pkg/gpg/gpg.go
+++ b/pkg/gpg/gpg.go
@@ -52,6 +52,10 @@ func (gpg *GPG) Decrypt(ctx context.Context, dec string) (string, *Status, error
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
 	cmd := exec.CommandContext(ctx, gpg.GPG, "--batch", "--no-tty")
+
+	// Ensure that US gpg strings are used in gpg tp match regexp.
+	cmd.Env = append(os.Environ(), "LC_MESSAGES=C")
+
 	if gpg.Passphrase != "" {
 		// Used for testing.
 		cmd.Args = append(cmd.Args,
@@ -105,6 +109,10 @@ func (gpg *GPG) Verify(ctx context.Context, data, sig string) (*Status, error) {
 
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, gpg.GPG, "--verify", "--no-tty", sigFN, dataFN)
+
+	// Ensure that US gpg strings are used in gpg tp match regexp.
+	cmd.Env = append(os.Environ(), "LC_MESSAGES=C")
+
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		return nil, errors.Wrapf(err, "failed to start gpg (%q)", gpg.GPG)
@@ -144,6 +152,10 @@ func (gpg *GPG) Verify(ctx context.Context, data, sig string) (*Status, error) {
 func (gpg *GPG) VerifyInline(ctx context.Context, data string) (*Status, error) {
 	var stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, gpg.GPG, "--verify", "--no-tty", "-")
+
+	// Ensure that US gpg strings are used in gpg tp match regexp.
+	cmd.Env = append(os.Environ(), "LC_MESSAGES=C")
+
 	cmd.Stderr = &stderr
 	cmd.Stdin = strings.NewReader(data)
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
see issues #143 for origin of this PR.

Before my modifications:

```
go test ./pkg/gpg/
gpg: Generating a basic OpenPGP key
gpg: répertoire « /tmp/gpg-test2282604550/openpgp-revocs.d » créé
gpg: revocation certificate stored as '/tmp/gpg-test2282604550/openpgp-revocs.d/F01C61BA2AE615B79CC00C8914A85AC026D20653.rev'
gpg: done
time="2026-01-08T21:25:23+01:00" level=info msg="Checking signature with \"/tmp/gpg-signature3372013712\"…"
time="2026-01-08T21:25:23+01:00" level=info msg="Checking signature with \"/tmp/gpg-signature2108591996\"…"
--- FAIL: TestVerify (0.00s)
    gpg_test.go:139: "good": Failed to verify: signature not good nor bad. What? "gpg: Signature faite le jeu. 14 mai 2020 11:04:39 CEST\ngpg:                avec la clef RSA 990786988A24F52F1C2E87F639A49EEA460A0169\ngpg: vérification de la base de confiance\ngpg: marginals needed: 3  completes needed: 1  trust model: pgp\ngpg: profondeur\u00a0: 0  valables\u00a0:   1  signées\u00a0:   0\n     confiance\u00a0: 0\u00a0i., 0\u00a0n.d., 0\u00a0j., 0\u00a0m., 0\u00a0t., 1\u00a0u.\ngpg: Bonne signature de «\u00a0Thomas Habets <thomas@habets.se>\u00a0» [expirée]\ngpg: Remarque\u00a0: cette clef a expiré.\nEmpreinte de clef principale\u00a0: 9907 8698 8A24 F52F 1C2E  87F6 39A4 9EEA 460A 0169\n"
--- FAIL: TestVerifyInline (0.00s)
    gpg_test.go:197: "good": Failed to verify: signature not good nor bad. What? "gpg: Signature faite le jeu. 14 mai 2020 11:04:56 CEST\ngpg:                avec la clef RSA 990786988A24F52F1C2E87F639A49EEA460A0169\ngpg: Bonne signature de «\u00a0Thomas Habets <thomas@habets.se>\u00a0» [expirée]\ngpg: Remarque\u00a0: cette clef a expiré.\nEmpreinte de clef principale\u00a0: 9907 8698 8A24 F52F 1C2E  87F6 39A4 9EEA 460A 0169\n"
FAIL
FAIL    github.com/ThomasHabets/cmdg/pkg/gpg    3.563s
FAIL

```
But if doing this
```
LC_MESSAGES=C go test  ./pkg/gpg/
ok      github.com/ThomasHabets/cmdg/pkg/gpg    3.747s

```

So made changes to the gpg cmd env to ensure that the messages are the right ones in all conditions.

After that:
```
go test  ./pkg/gpg/
ok      github.com/ThomasHabets/cmdg/pkg/gpg    3.688s
```